### PR TITLE
016 Fix typo in GitHub Actions

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -7,30 +7,30 @@ on:
 
 jobs:
   build:
-  runs-on: ubuntu-latest
-  steps:
-    - name: Check out
-      uses: actions/checkout@v5
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v5
 
-    - name: Get image version
-      id: get_image_version
-      run: |
-        pip install toml
-        VERSION=$(python -c "import toml; print(toml.load('pyproject.toml')['project']['version'])")
-        echo "VERSION=$VERSION" >> $GITHUB_ENV
-        echo "Image version: $VERSION"
+      - name: Get image version
+        id: get_image_version
+        run: |
+          pip install toml
+          VERSION=$(python -c "import toml; print(toml.load('pyproject.toml')['project']['version'])")
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "Image version: $VERSION"
 
-    - name: Login to Docker Hub
-      uses: docker/login-action@v3
-      with:
-        username: ${{ vars.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-    - name: Build and push to Docker Hub
-      uses: docker/build-push-action@v6
-      with: 
-        context: .
-        push: true
-        tags: |
-          ${{ vars.DOCKERHUB_USERNAME }}/bin-it:latest
-          ${{ vars.DOCKERHUB_USERNAME }}/bin-it:${{ env.VERSION }}
+      - name: Build and push to Docker Hub
+        uses: docker/build-push-action@v6
+        with: 
+          context: .
+          push: true
+          tags: |
+            ${{ vars.DOCKERHUB_USERNAME }}/bin-it:latest
+            ${{ vars.DOCKERHUB_USERNAME }}/bin-it:${{ env.VERSION }}


### PR DESCRIPTION
Missing indentation on line 9 of `publish.yaml` file causing GitHub Action to throw error and fail to run immediately.
